### PR TITLE
Resize window, transport mouse, and more.

### DIFF
--- a/DeskPad/AppDelegate.swift
+++ b/DeskPad/AppDelegate.swift
@@ -11,12 +11,17 @@ class AppDelegate: NSObject, NSApplicationDelegate {
     func applicationDidFinishLaunching(_: Notification) {
         let viewController = ScreenViewController()
         window = NSWindow(contentViewController: viewController)
+        window.delegate = viewController
         window.title = "DeskPad"
         window.makeKeyAndOrderFront(nil)
-        window?.titlebarAppearsTransparent = true
+        window.titlebarAppearsTransparent = true
         window.isMovableByWindowBackground = true
         window.titleVisibility = .hidden
         window.backgroundColor = .white
+        window.contentMinSize = CGSize(width: 400, height: 300)
+        window.contentMaxSize = CGSize(width: 3840, height: 2160)
+        window.styleMask.insert(.resizable)
+        window.collectionBehavior.insert(.fullScreenNone)
 
         let mainMenu = NSMenu()
         let mainMenuItem = NSMenuItem()

--- a/DeskPad/Backend/MouseLocation/MouseLocationSideEffect.swift
+++ b/DeskPad/Backend/MouseLocation/MouseLocationSideEffect.swift
@@ -5,10 +5,11 @@ private var timer: Timer?
 
 enum MouseLocationAction: Action {
     case located(isWithinScreen: Bool)
+    case requestMove(toPoint: NSPoint)
 }
 
 func mouseLocationSideEffect() -> SideEffect {
-    return { _, dispatch, getState in
+    return { action, dispatch, getState in
         if timer == nil {
             timer = Timer.scheduledTimer(withTimeInterval: 0.25, repeats: true) { _ in
                 let mouseLocation = NSEvent.mouseLocation
@@ -17,6 +18,15 @@ func mouseLocationSideEffect() -> SideEffect {
                 let isWithinScreen = screenContainingMouse?.displayID == getState()?.screenConfigurationState.displayID
                 dispatch(MouseLocationAction.located(isWithinScreen: isWithinScreen))
             }
+        }
+        switch action {
+        case let MouseLocationAction.requestMove(point):
+            guard let displayID = getState()?.screenConfigurationState.displayID else {
+                return
+            }
+            CGDisplayMoveCursorToPoint(displayID, point)
+        default:
+            return
         }
     }
 }

--- a/DeskPad/Frontend/Screen/ScreenViewController.swift
+++ b/DeskPad/Frontend/Screen/ScreenViewController.swift
@@ -9,6 +9,7 @@ class ScreenViewController: SubscriberViewController<ScreenViewData>, NSWindowDe
     override func loadView() {
         view = NSView()
         view.wantsLayer = true
+        view.addGestureRecognizer(NSClickGestureRecognizer(target: self, action: #selector(didClickOnScreen)))
     }
 
     private var display: CGVirtualDisplay!
@@ -95,5 +96,18 @@ class ScreenViewController: SubscriberViewController<ScreenViewData>, NSWindowDe
             return frameSize
         }
         return window.frameRect(forContentRect: NSRect(origin: .zero, size: screenResolution)).size
+    }
+
+    @objc private func didClickOnScreen(_ gestureRecoginizer: NSGestureRecognizer) {
+        guard let screenResolution = previousResolution else {
+            return
+        }
+        let clickedPoint = gestureRecoginizer.location(in: view)
+        let onScreenPoint = NSPoint(
+            x: clickedPoint.x / view.frame.width * screenResolution.width,
+            y: (view.frame.height - clickedPoint.y) / view.frame.height * screenResolution.height
+        )
+        print("\(clickedPoint), \(onScreenPoint)")
+        store.dispatch(MouseLocationAction.requestMove(toPoint: onScreenPoint))
     }
 }

--- a/DeskPad/Frontend/Screen/ScreenViewController.swift
+++ b/DeskPad/Frontend/Screen/ScreenViewController.swift
@@ -90,7 +90,7 @@ class ScreenViewController: SubscriberViewController<ScreenViewData>, NSWindowDe
     }
 
     func windowWillResize(_ window: NSWindow, to frameSize: NSSize) -> NSSize {
-        let snappingOffset: CGFloat = 20
+        let snappingOffset: CGFloat = 30
         let contentSize = window.contentRect(forFrameRect: NSRect(origin: .zero, size: frameSize)).size
         guard
             let screenResolution = previousResolution,

--- a/DeskPad/Frontend/Screen/ScreenViewController.swift
+++ b/DeskPad/Frontend/Screen/ScreenViewController.swift
@@ -110,7 +110,6 @@ class ScreenViewController: SubscriberViewController<ScreenViewData>, NSWindowDe
             x: clickedPoint.x / view.frame.width * screenResolution.width,
             y: (view.frame.height - clickedPoint.y) / view.frame.height * screenResolution.height
         )
-        print("\(clickedPoint), \(onScreenPoint)")
         store.dispatch(MouseLocationAction.requestMove(toPoint: onScreenPoint))
     }
 }

--- a/DeskPad/Frontend/Screen/ScreenViewController.swift
+++ b/DeskPad/Frontend/Screen/ScreenViewController.swift
@@ -23,8 +23,8 @@ class ScreenViewController: SubscriberViewController<ScreenViewData>, NSWindowDe
         let descriptor = CGVirtualDisplayDescriptor()
         descriptor.setDispatchQueue(DispatchQueue.main)
         descriptor.name = "DeskPad Display"
-        descriptor.maxPixelsWide = 1920
-        descriptor.maxPixelsHigh = 1200
+        descriptor.maxPixelsWide = 3840
+        descriptor.maxPixelsHigh = 2160
         descriptor.sizeInMillimeters = CGSize(width: 1600, height: 1000)
         descriptor.productID = 0x1234
         descriptor.vendorID = 0x3456
@@ -101,11 +101,11 @@ class ScreenViewController: SubscriberViewController<ScreenViewData>, NSWindowDe
         return window.frameRect(forContentRect: NSRect(origin: .zero, size: screenResolution)).size
     }
 
-    @objc private func didClickOnScreen(_ gestureRecoginizer: NSGestureRecognizer) {
+    @objc private func didClickOnScreen(_ gestureRecognizer: NSGestureRecognizer) {
         guard let screenResolution = previousResolution else {
             return
         }
-        let clickedPoint = gestureRecoginizer.location(in: view)
+        let clickedPoint = gestureRecognizer.location(in: view)
         let onScreenPoint = NSPoint(
             x: clickedPoint.x / view.frame.width * screenResolution.width,
             y: (view.frame.height - clickedPoint.y) / view.frame.height * screenResolution.height

--- a/DeskPad/Frontend/Screen/ScreenViewController.swift
+++ b/DeskPad/Frontend/Screen/ScreenViewController.swift
@@ -38,11 +38,14 @@ class ScreenViewController: SubscriberViewController<ScreenViewData>, NSWindowDe
         settings.hiDPI = 1
         settings.modes = [
             // 16:9
+            CGVirtualDisplayMode(width: 3840, height: 2160, refreshRate: 60),
+            CGVirtualDisplayMode(width: 2560, height: 1440, refreshRate: 60),
             CGVirtualDisplayMode(width: 1920, height: 1080, refreshRate: 60),
             CGVirtualDisplayMode(width: 1600, height: 900, refreshRate: 60),
             CGVirtualDisplayMode(width: 1366, height: 768, refreshRate: 60),
             CGVirtualDisplayMode(width: 1280, height: 720, refreshRate: 60),
             // 16:10
+            CGVirtualDisplayMode(width: 2560, height: 1600, refreshRate: 60),
             CGVirtualDisplayMode(width: 1920, height: 1200, refreshRate: 60),
             CGVirtualDisplayMode(width: 1680, height: 1050, refreshRate: 60),
             CGVirtualDisplayMode(width: 1440, height: 900, refreshRate: 60),


### PR DESCRIPTION
This pull request addresses the following improvements:
- The visible window is now resizable so that it can occupy as much space as the user wants, regardless of the resolution of the virtual display. This is helpful to optimize the size of the window in the physical display. This feature addresses issues https://github.com/Stengo/DeskPad/issues/11 and https://github.com/Stengo/DeskPad/issues/2.
- DeskPad captures the clicks over the visible window, and when that happens, the coordinates are converted to the coordinates of the virtual display, and the cursor is moved. This feature addresses issues https://github.com/Stengo/DeskPad/issues/12 and https://github.com/Stengo/DeskPad/issues/13. This feature is configurable through a new checkbox in the menu.
- Added more standard display resolutions
- Issue https://github.com/Stengo/DeskPad/issues/6 is partially addressed. The lacking feature is to detect if the cursor is on the edge of the virtual cursor. In that case, we want to move the cursor to the display where the visible window is shown in the position corresponding to the edge of the window.
