### PR TITLE
Add 32:9 & 21:9 ultrawide resolutions

### DIFF
--- a/DeskPad/AppDelegate.swift
+++ b/DeskPad/AppDelegate.swift
@@ -19,7 +19,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         window.titleVisibility = .hidden
         window.backgroundColor = .white
         window.contentMinSize = CGSize(width: 400, height: 300)
-        window.contentMaxSize = CGSize(width: 3840, height: 2160)
+        window.contentMaxSize = CGSize(width: 5120, height: 2160)
         window.styleMask.insert(.resizable)
         window.collectionBehavior.insert(.fullScreenNone)
 

--- a/DeskPad/Frontend/Screen/ScreenViewController.swift
+++ b/DeskPad/Frontend/Screen/ScreenViewController.swift
@@ -24,7 +24,7 @@ class ScreenViewController: SubscriberViewController<ScreenViewData>, NSWindowDe
         let descriptor = CGVirtualDisplayDescriptor()
         descriptor.setDispatchQueue(DispatchQueue.main)
         descriptor.name = "DeskPad Display"
-        descriptor.maxPixelsWide = 3840
+        descriptor.maxPixelsWide = 5120
         descriptor.maxPixelsHigh = 2160
         descriptor.sizeInMillimeters = CGSize(width: 1600, height: 1000)
         descriptor.productID = 0x1234
@@ -38,6 +38,12 @@ class ScreenViewController: SubscriberViewController<ScreenViewData>, NSWindowDe
         let settings = CGVirtualDisplaySettings()
         settings.hiDPI = 1
         settings.modes = [
+            // 32:9
+            CGVirtualDisplayMode(width: 5120, height: 1440, refreshRate: 60),
+            // 21:9 (239:100, 12:5)
+            CGVirtualDisplayMode(width: 5120, height: 2160, refreshRate: 60),
+            CGVirtualDisplayMode(width: 3840, height: 1600, refreshRate: 60),
+            CGVirtualDisplayMode(width: 3440, height: 1440, refreshRate: 60),
             // 16:9
             CGVirtualDisplayMode(width: 3840, height: 2160, refreshRate: 60),
             CGVirtualDisplayMode(width: 2560, height: 1440, refreshRate: 60),


### PR DESCRIPTION
1. Add a `32:9` (356:100) ultrawide resolution of `5120x1440`.
2. Add the following 3 `21:9` (233:100) ultrawide resolution:
    * `5120x2160` (technically 237:100)
    * `3840x1600` (technically 240:100)
    * `3440x1440` (technically 239:100)

I came up with these resolutions by looking at a few mainstream articles on ultrawide monitors, e.g. https://www.pcmag.com/picks/the-best-ultrawide-monitors

Continuation (of sorts) of https://github.com/Stengo/DeskPad/pull/16, which mentions ultrawide resolutions, and https://github.com/Stengo/DeskPad/pull/10 (which added 16:10 resolutions).