### PR TITLE
Use processIdentifier to allow multiple screens

### DIFF
--- a/DeskPad/AppDelegate.swift
+++ b/DeskPad/AppDelegate.swift
@@ -9,14 +9,14 @@ class AppDelegate: NSObject, NSApplicationDelegate {
     var window: NSWindow!
 
     func applicationDidFinishLaunching(_: Notification) {
+        let pid = ProcessInfo().processIdentifier
         let viewController = ScreenViewController()
         window = NSWindow(contentViewController: viewController)
         window.delegate = viewController
-        window.title = "DeskPad"
+        window.title = "DeskPad (" + String(pid) + ")"
         window.makeKeyAndOrderFront(nil)
         window.titlebarAppearsTransparent = true
         window.isMovableByWindowBackground = true
-        window.titleVisibility = .hidden
         window.backgroundColor = .white
         window.contentMinSize = CGSize(width: 400, height: 300)
         window.contentMaxSize = CGSize(width: 3840, height: 2160)

--- a/DeskPad/Frontend/Screen/ScreenViewController.swift
+++ b/DeskPad/Frontend/Screen/ScreenViewController.swift
@@ -20,16 +20,17 @@ class ScreenViewController: SubscriberViewController<ScreenViewData>, NSWindowDe
 
     override func viewDidLoad() {
         super.viewDidLoad()
-
+        
+        let pid = ProcessInfo().processIdentifier
         let descriptor = CGVirtualDisplayDescriptor()
         descriptor.setDispatchQueue(DispatchQueue.main)
-        descriptor.name = "DeskPad Display"
+        descriptor.name = "DeskPad Display (" + String(pid) + ")"
         descriptor.maxPixelsWide = 3840
         descriptor.maxPixelsHigh = 2160
         descriptor.sizeInMillimeters = CGSize(width: 1600, height: 1000)
         descriptor.productID = 0x1234
         descriptor.vendorID = 0x3456
-        descriptor.serialNum = 0x0001
+        descriptor.serialNum = uint32(pid)
 
         let display = CGVirtualDisplay(descriptor: descriptor)
         store.dispatch(ScreenViewAction.setDisplayID(display.displayID))


### PR DESCRIPTION
Closes #20

You can have multiple screens by either copying the app or by using `open -n /Applications/DeskPad.app`

But brings in a new set of problems..

- Because the display is no longer the same on each run, **macOS probably won't save the screen arrangement anymore** (and you'll probably trash your hidden macOS config as it sees a new display on each run, so you accumulate more displays than normally possible).
    - A temporary solution might be to look for the number of application instances and only attach the PID if there is already another instance.
- The index of each display is likely similar, but quite long; so it's hard to differentiate windows easily.
    - A temporary solution might be to include the bundle filename, so users can have their own names for virtual displays.

I also barely tested this (due to macOS permissions being problematic when running from xcode), but I'll probably have a couple of real-world use-cases in the next couple of months where I'll actually test this.

---

I'm not a swift coder, so this is just the bare minimum to get the ball rolling.

I've also tried or thought about other strategies for display-names / serial numbers:
- Start at serial-number 1, then iterated over NSScreens.screens to find a free name, incrementing the serial-number on collisions: this would likely lead to race-conditions; it also needs more changes for communication between AppDelegate and ScreenViewController.
- Use the bundle path as identifier, so users can have named displays and hash the bundle-path to get a unique serial number. Unfortunately, this would still break for multiple instances.

I think the best option would be to allow configuring the amount of displays the user wants for a single instance.
However, I don't know enough swift to actually work on this myself.

Hopefully someone is being nerd-sniped here to actually work on a proper implementation.