### PR TITLE
Fix `brew install` command in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ DeskPad creates a virtual display that is mirrored within its application window
 
 # Installation
 
-You can either download the [latest release binary](https://github.com/Stengo/DeskPad/releases) or install via [Homebrew](https://brew.sh) by calling `brew install deskpad`.
+You can either download the [latest release binary](https://github.com/Stengo/DeskPad/releases) or install via [Homebrew](https://brew.sh) by calling `brew install --cask deskpad`.
 
 # Usage
 DeskPad behaves like any other display. Launching the app is equivalent to plugging in a monitor, so macOS will take care of properly arranging your windows to their previous configuration.


### PR DESCRIPTION
This is a simple fix for README.md instructions on how to install DeskPad using homebrew. This is a cask recipe so will need to be installed using 

```bash
brew install --cask deskpad
```